### PR TITLE
update xaringan link to avoid 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Rscript -e "rmarkdown::render('xaringan.Rmd', output_file = 'r/xaringan.html')"
 - [ioslides](https://marskar.github.io/slides/r/ioslides-r.html)
 - [slidy](https://marskar.github.io/slides/r/slidy-r.html)
 - [revealjs](https://marskar.github.io/slides/r/revealjs-r.html)
-- [xaringan](https://marskar.github.io/slides/r/xaringan-r.html)
+- [xaringan](https://marskar.github.io/slides/r/xaringan.html)
 
 ## Create HTML slides from ipynb using [nbconvert](https://nbconvert.readthedocs.io/en/latest/) from the command-line
 


### PR DESCRIPTION
Noticed the link to the xaringan slides was broken and lead to 404 error. Removed `-r` from the URL reference.

May be worth updating the file name to match style of the others?

They now read:
```
### Examples of HTML slides created using [RStudio](https://www.rstudio.com/products/rstudio/download/) or the [rmarkdown R package](https://github.com/rstudio/rmarkdown):
- [ioslides](https://marskar.github.io/slides/r/ioslides-r.html)
- [slidy](https://marskar.github.io/slides/r/slidy-r.html)
- [revealjs](https://marskar.github.io/slides/r/revealjs-r.html)
- [xaringan](https://marskar.github.io/slides/r/xaringan.html)
```